### PR TITLE
Updating requirements to work with python 3.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,5 @@ h5py
 # onnx==1.8.1
 # onnxruntime==1.8.0
 onnx==1.17.0
-onnxruntime==1.20.1
+onnxruntime==1.19.2
 onnx-simplifier==0.3.5


### PR DESCRIPTION
Downgrade onnxruntime version for compatibility with Python 3.9
